### PR TITLE
fix(): add dependencies to be able to run notebooks on colab

### DIFF
--- a/scripts/colab_reqs/rome.txt
+++ b/scripts/colab_reqs/rome.txt
@@ -1,3 +1,5 @@
 datasets==1.18.3
 python-dotenv==0.19.2
 git+https://github.com/kmeng01/transformers-colab@allennlp-compat
+transformers==4.33.1
+accelerate==0.23.0


### PR DESCRIPTION
Hi! I was trying to run the `causal_trace.ipynb` in colab, but it was throwing some error for some missing dependencies :)

This is the error it was throwing before
<img width="785" alt="image" src="https://github.com/kmeng01/rome/assets/58240958/92641de6-2774-46d4-b365-72f5db85eb18">


And now it runs smoothly
